### PR TITLE
Bug fixed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,8 +152,6 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.9-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)


### PR DESCRIPTION
`You have already activated nokogiri 1.13.9, but your Gemfile requires nokogiri 1.13.10.`

Delete nokogiri 1.13.9