### PR TITLE
Set config.assets.compile to true for prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
It is needed for displaying pictures on heroku.
Before this change we got `assets no found` error