### PR TITLE
Don't hijack global container class

### DIFF
--- a/app/assets/stylesheets/components/_form_row.scss
+++ b/app/assets/stylesheets/components/_form_row.scss
@@ -1,4 +1,4 @@
-.container {
+.container-prescription {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/views/prescriptions/new.html.erb
+++ b/app/views/prescriptions/new.html.erb
@@ -1,5 +1,5 @@
 <h3 id="H1"> Doctor, please complete the form below </h3>
-<div class="container">
+<div class="container container-prescription">
   <%= simple_form_for @prescription do |f| %>
     <%= f.association :patient, collection: User.patients, label_method: :full_name %>
     <%= f.simple_fields_for @meds_prescription do |f| %>


### PR DESCRIPTION
As .container is widely used, any changes have a drastic impact. The new prescription page needs a distinct style, move those into .container-prescription.